### PR TITLE
Fix typo

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -20,7 +20,7 @@ There are four MacOS applications:
 - [RsyncGUI](https://github.com/rsyncOSX/RsyncGUI) an Apple Sandboxed version of RsyncOSX
 - [RcloneOSX](https://github.com/rsyncOSX/rcloneosx) a GUI for rclone
 
-All applications are compiled with support for macOS 10.14 - latest version of macOS.
+All applications are compiled with support for macOS 10.15 - latest version of macOS.
 
 ### Issues, missing features and enhancements
 

--- a/content/post/RsyncOSX.md
+++ b/content/post/RsyncOSX.md
@@ -20,7 +20,7 @@ will print the shasum for the .dmg file. For your own safety verify the shasums.
 `RsyncOSX 6.4.6.dmg: 12ea3768699946bdd43f6c4768187b7f6ba6245a`  
 `RsyncOSXsched 6.4.6.dmg: a9e9b797c8c9bf455f921e50499b54bd4296533d`
 
-To install RsyncOSX open the downloaded RsyncOSX-version.dmg file. Drag the RsyncOSX icon to the default `/Application` catalog or any other preferred catalog for install. And likewise for the RsyncOSXsched-version.dmg.
+To install RsyncOSX open the downloaded RsyncOSX-version.dmg file. Drag the RsyncOSX icon to the default `/Applications` catalog or any other preferred catalog for install. And likewise for the RsyncOSXsched-version.dmg.
 ![](/images/RsyncOSX/master/install/install.png)
 RsyncOSX is installed and used at your own risk. The developer accepts no responsibility for any errors, omissions or loss of data by using the application.
 


### PR DESCRIPTION
This is literally adding a missing "s" to `/Applications`, and updating a version number, just because I happened to notice it while actually reading the docs. Hope to contribute something more substantial in the future. ;)

Found this app while looking for a good GUI rsync-client for a client of mine, and this looks great. And the site is even built in Hugo, which I love.

Really good documentation, I absolutely like it. Haven't had time to actually play around with it myself, but I'm planning to do a screencast about the basics. (In Dutch, since my clients usually aren't that fluent in English.)

Sorry, lots of text for such small changes, just wanted to thank you for the work.